### PR TITLE
feat: implement cross-chain correlation via GUID matching

### DIFF
--- a/internal/chain/client.go
+++ b/internal/chain/client.go
@@ -28,6 +28,7 @@ const (
 type EthClient interface {
 	BlockNumber(ctx context.Context) (uint64, error)
 	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
+	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	Close()
 }
 
@@ -172,6 +173,23 @@ func (c *Client) FetchLogs(ctx context.Context, fromBlock, toBlock uint64, addre
 	}
 
 	return allLogs, nil
+}
+
+// BlockTimestamp returns the timestamp (unix seconds) for a given block number.
+func (c *Client) BlockTimestamp(ctx context.Context, blockNumber uint64) (int64, error) {
+	var header *types.Header
+	err := c.withRetry(ctx, func(ctx context.Context) error {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return fmt.Errorf("rate limiter: %w", err)
+		}
+		var err error
+		header, err = c.eth.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNumber))
+		return err
+	})
+	if err != nil {
+		return 0, fmt.Errorf("fetching header for block %d: %w", blockNumber, err)
+	}
+	return int64(header.Time), nil
 }
 
 // Close closes the underlying RPC connection.

--- a/internal/chain/client_test.go
+++ b/internal/chain/client_test.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
@@ -18,6 +19,8 @@ type mockEthClient struct {
 	filterLogs     []types.Log
 	filterLogsErr  error
 	filterCalls    int
+	header         *types.Header
+	headerErr      error
 	closed         bool
 }
 
@@ -28,6 +31,10 @@ func (m *mockEthClient) BlockNumber(_ context.Context) (uint64, error) {
 func (m *mockEthClient) FilterLogs(_ context.Context, _ ethereum.FilterQuery) ([]types.Log, error) {
 	m.filterCalls++
 	return m.filterLogs, m.filterLogsErr
+}
+
+func (m *mockEthClient) HeaderByNumber(_ context.Context, _ *big.Int) (*types.Header, error) {
+	return m.header, m.headerErr
 }
 
 func (m *mockEthClient) Close() {

--- a/internal/correlator/correlator.go
+++ b/internal/correlator/correlator.go
@@ -1,0 +1,79 @@
+package correlator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/normalizer"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/types"
+)
+
+// MessageStore is the subset of indexer.MessageStore needed by the correlator.
+type MessageStore interface {
+	UpsertMessage(ctx context.Context, msg *types.Message) error
+	FindByCorrelationKey(ctx context.Context, key *normalizer.CorrelationKey) (*types.Message, error)
+	UpdateDestination(ctx context.Context, messageID string, dest *types.Destination, status types.MessageStatus) error
+}
+
+// Correlator handles cross-chain message matching by routing decoded events
+// through the normalizer and persisting or correlating them via the message store.
+type Correlator struct {
+	store MessageStore
+	log   zerolog.Logger
+}
+
+// New creates a new Correlator.
+func New(store MessageStore, log zerolog.Logger) *Correlator {
+	return &Correlator{
+		store: store,
+		log:   log.With().Str("component", "correlator").Logger(),
+	}
+}
+
+// Process normalizes a decoded event and either stores it as a new message
+// or correlates it with an existing one.
+func (c *Correlator) Process(ctx context.Context, event *decoder.RawEvent) error {
+	result, err := normalizer.Normalize(event)
+	if err != nil {
+		return fmt.Errorf("normalizing event: %w", err)
+	}
+
+	if result.IsCorrelation {
+		return c.correlate(ctx, event, result)
+	}
+
+	return c.store.UpsertMessage(ctx, result.Message)
+}
+
+// correlate finds an existing pending message and updates it with destination details.
+func (c *Correlator) correlate(ctx context.Context, event *decoder.RawEvent, result *normalizer.Result) error {
+	existing, err := c.store.FindByCorrelationKey(ctx, result.CorrelationKey)
+	if err != nil {
+		return fmt.Errorf("finding message for correlation: %w", err)
+	}
+
+	if existing == nil {
+		c.log.Warn().
+			Str("event_type", event.EventType).
+			Uint64("nonce", result.CorrelationKey.Nonce).
+			Str("sender", result.CorrelationKey.Sender).
+			Uint64("src_chain_id", result.CorrelationKey.SrcChainID).
+			Msg("No pending message found for correlation, skipping")
+		return nil
+	}
+
+	err = c.store.UpdateDestination(ctx, existing.MessageID, result.Message.Destination, types.StatusExecuted)
+	if err != nil {
+		return fmt.Errorf("updating destination for message %s: %w", existing.MessageID, err)
+	}
+
+	c.log.Info().
+		Str("message_id", existing.MessageID).
+		Str("status", string(types.StatusExecuted)).
+		Msg("Correlated destination event with existing message")
+
+	return nil
+}

--- a/internal/correlator/correlator_test.go
+++ b/internal/correlator/correlator_test.go
@@ -1,0 +1,275 @@
+package correlator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/normalizer"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/types"
+)
+
+// mockMessageStore implements MessageStore for testing.
+type mockMessageStore struct {
+	upserted       []*types.Message
+	findResult     *types.Message
+	findErr        error
+	updateDestCall *updateDestCall
+	updateDestErr  error
+}
+
+type updateDestCall struct {
+	MessageID string
+	Dest      *types.Destination
+	Status    types.MessageStatus
+}
+
+func (m *mockMessageStore) UpsertMessage(_ context.Context, msg *types.Message) error {
+	m.upserted = append(m.upserted, msg)
+	return nil
+}
+
+func (m *mockMessageStore) FindByCorrelationKey(_ context.Context, _ *normalizer.CorrelationKey) (*types.Message, error) {
+	return m.findResult, m.findErr
+}
+
+func (m *mockMessageStore) UpdateDestination(_ context.Context, messageID string, dest *types.Destination, status types.MessageStatus) error {
+	m.updateDestCall = &updateDestCall{
+		MessageID: messageID,
+		Dest:      dest,
+		Status:    status,
+	}
+	return m.updateDestErr
+}
+
+func newTestCorrelator(store *mockMessageStore) *Correlator {
+	log := zerolog.Nop()
+	return New(store, log)
+}
+
+func TestProcess_PacketSent_UpsertsCalled(t *testing.T) {
+	store := &mockMessageStore{}
+	c := newTestCorrelator(store)
+
+	event := &decoder.RawEvent{
+		Protocol:    "layerzero_v2",
+		ChainID:     1,
+		BlockNumber: 19000000,
+		TxHash:      "0xabc123",
+		LogIndex:    5,
+		Timestamp:   1706000000,
+		EventType:   "PacketSent",
+		Data: map[string]string{
+			"guid":    "0x1234",
+			"nonce":   "42",
+			"sender":  "0xSender",
+			"message": "0xdeadbeef",
+		},
+	}
+
+	err := c.Process(context.Background(), event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(store.upserted) != 1 {
+		t.Fatalf("expected 1 upsert, got %d", len(store.upserted))
+	}
+
+	msg := store.upserted[0]
+	if msg.MessageID != "0x1234" {
+		t.Errorf("expected message_id 0x1234, got %s", msg.MessageID)
+	}
+	if msg.Status != types.StatusPending {
+		t.Errorf("expected status pending, got %s", msg.Status)
+	}
+}
+
+func TestProcess_OFTSent_UpsertsCalled(t *testing.T) {
+	store := &mockMessageStore{}
+	c := newTestCorrelator(store)
+
+	event := &decoder.RawEvent{
+		Protocol:    "layerzero_v2",
+		ChainID:     1,
+		BlockNumber: 19000000,
+		TxHash:      "0xabc123",
+		LogIndex:    6,
+		Timestamp:   1706000000,
+		EventType:   "OFTSent",
+		Data: map[string]string{
+			"guid":            "0x5678",
+			"from_address":    "0xSender",
+			"amount_sent":     "1000",
+			"amount_received": "999",
+		},
+	}
+
+	err := c.Process(context.Background(), event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(store.upserted) != 1 {
+		t.Fatalf("expected 1 upsert, got %d", len(store.upserted))
+	}
+
+	msg := store.upserted[0]
+	if msg.Type != types.TypeTokenTransfer {
+		t.Errorf("expected type token_transfer, got %s", msg.Type)
+	}
+}
+
+func TestProcess_PacketReceived_CorrelatesExisting(t *testing.T) {
+	existing := &types.Message{
+		MessageID: "0x1234",
+		Protocol:  "layerzero_v2",
+		Status:    types.StatusPending,
+	}
+	store := &mockMessageStore{findResult: existing}
+	c := newTestCorrelator(store)
+
+	event := &decoder.RawEvent{
+		Protocol:    "layerzero_v2",
+		ChainID:     42161,
+		BlockNumber: 180000000,
+		TxHash:      "0xdef456",
+		LogIndex:    3,
+		Timestamp:   1706000045,
+		EventType:   "PacketReceived",
+		Data: map[string]string{
+			"nonce":        "42",
+			"sender":       "0xSender",
+			"receiver":     "0xReceiver",
+			"src_chain_id": "1",
+		},
+	}
+
+	err := c.Process(context.Background(), event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should not have upserted a new message
+	if len(store.upserted) != 0 {
+		t.Errorf("expected 0 upserts, got %d", len(store.upserted))
+	}
+
+	// Should have called UpdateDestination
+	if store.updateDestCall == nil {
+		t.Fatal("expected UpdateDestination to be called")
+	}
+	if store.updateDestCall.MessageID != "0x1234" {
+		t.Errorf("expected message_id 0x1234, got %s", store.updateDestCall.MessageID)
+	}
+	if store.updateDestCall.Status != types.StatusExecuted {
+		t.Errorf("expected status executed, got %s", store.updateDestCall.Status)
+	}
+	if store.updateDestCall.Dest.ChainID != 42161 {
+		t.Errorf("expected dest chain_id 42161, got %d", store.updateDestCall.Dest.ChainID)
+	}
+	if store.updateDestCall.Dest.Receiver != "0xReceiver" {
+		t.Errorf("expected dest receiver 0xReceiver, got %s", store.updateDestCall.Dest.Receiver)
+	}
+}
+
+func TestProcess_PacketReceived_NoMatchSkips(t *testing.T) {
+	store := &mockMessageStore{findResult: nil}
+	c := newTestCorrelator(store)
+
+	event := &decoder.RawEvent{
+		Protocol:    "layerzero_v2",
+		ChainID:     42161,
+		BlockNumber: 180000000,
+		TxHash:      "0xdef456",
+		LogIndex:    3,
+		Timestamp:   1706000045,
+		EventType:   "PacketReceived",
+		Data: map[string]string{
+			"nonce":        "99",
+			"sender":       "0xUnknown",
+			"receiver":     "0xReceiver",
+			"src_chain_id": "1",
+		},
+	}
+
+	err := c.Process(context.Background(), event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should not have called UpdateDestination
+	if store.updateDestCall != nil {
+		t.Error("expected UpdateDestination to NOT be called for unmatched event")
+	}
+}
+
+func TestProcess_PacketReceived_FindError(t *testing.T) {
+	store := &mockMessageStore{findErr: fmt.Errorf("db connection lost")}
+	c := newTestCorrelator(store)
+
+	event := &decoder.RawEvent{
+		Protocol:  "layerzero_v2",
+		ChainID:   42161,
+		EventType: "PacketReceived",
+		Data: map[string]string{
+			"nonce":        "42",
+			"sender":       "0xSender",
+			"receiver":     "0xReceiver",
+			"src_chain_id": "1",
+		},
+	}
+
+	err := c.Process(context.Background(), event)
+	if err == nil {
+		t.Fatal("expected error when FindByCorrelationKey fails")
+	}
+}
+
+func TestProcess_PacketReceived_UpdateDestError(t *testing.T) {
+	existing := &types.Message{
+		MessageID: "0x1234",
+		Protocol:  "layerzero_v2",
+		Status:    types.StatusPending,
+	}
+	store := &mockMessageStore{
+		findResult:    existing,
+		updateDestErr: fmt.Errorf("db write failed"),
+	}
+	c := newTestCorrelator(store)
+
+	event := &decoder.RawEvent{
+		Protocol:  "layerzero_v2",
+		ChainID:   42161,
+		EventType: "PacketReceived",
+		Data: map[string]string{
+			"nonce":        "42",
+			"sender":       "0xSender",
+			"receiver":     "0xReceiver",
+			"src_chain_id": "1",
+		},
+	}
+
+	err := c.Process(context.Background(), event)
+	if err == nil {
+		t.Fatal("expected error when UpdateDestination fails")
+	}
+}
+
+func TestProcess_UnsupportedEventType(t *testing.T) {
+	store := &mockMessageStore{}
+	c := newTestCorrelator(store)
+
+	event := &decoder.RawEvent{
+		EventType: "UnknownEvent",
+		Data:      map[string]string{},
+	}
+
+	err := c.Process(context.Background(), event)
+	if err == nil {
+		t.Fatal("expected error for unsupported event type")
+	}
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/chain"
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/config"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/correlator"
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder"
 )
 
@@ -61,6 +62,10 @@ func (idx *Indexer) Start(ctx context.Context) error {
 		Strs("protocols", idx.registry.Protocols()).
 		Msg("Decoders loaded")
 
+	// Create message store and correlator
+	messages := NewPostgresMessageStore(idx.pool)
+	corr := correlator.New(messages, idx.log)
+
 	// WaitGroup to track all processor goroutines
 	var wg sync.WaitGroup
 
@@ -104,6 +109,7 @@ func (idx *Indexer) Start(ctx context.Context) error {
 					dec,
 					client,
 					idx.cursors,
+					corr,
 					uint64(idx.config.BatchSize),
 					idx.config.PollInterval,
 					idx.log,

--- a/internal/indexer/message_store.go
+++ b/internal/indexer/message_store.go
@@ -1,0 +1,25 @@
+package indexer
+
+import (
+	"context"
+
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/normalizer"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/types"
+)
+
+// MessageStore persists and retrieves cross-chain messages.
+type MessageStore interface {
+	// UpsertMessage inserts a new message or updates an existing one.
+	// Writes to messages, message_sources, message_payloads, and message_metadata
+	// tables atomically using ON CONFLICT for idempotent upserts.
+	UpsertMessage(ctx context.Context, msg *types.Message) error
+
+	// FindByCorrelationKey looks up an existing pending message using the
+	// composite key (protocol, nonce, sender, src_chain_id).
+	// Returns nil, nil if no matching message is found.
+	FindByCorrelationKey(ctx context.Context, key *normalizer.CorrelationKey) (*types.Message, error)
+
+	// UpdateDestination sets the destination details and updates the message status.
+	// Computes and stores latency when both source and destination timestamps are available.
+	UpdateDestination(ctx context.Context, messageID string, dest *types.Destination, status types.MessageStatus) error
+}

--- a/internal/indexer/message_store_pg.go
+++ b/internal/indexer/message_store_pg.go
@@ -1,0 +1,195 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/normalizer"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/types"
+)
+
+// PostgresMessageStore implements MessageStore using PostgreSQL.
+type PostgresMessageStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresMessageStore creates a new PostgresMessageStore.
+func NewPostgresMessageStore(pool *pgxpool.Pool) *PostgresMessageStore {
+	return &PostgresMessageStore{pool: pool}
+}
+
+// UpsertMessage inserts a new message or updates an existing one across all tables.
+func (s *PostgresMessageStore) UpsertMessage(ctx context.Context, msg *types.Message) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Upsert messages table
+	_, err = tx.Exec(ctx, `
+		INSERT INTO messages (message_id, protocol, type, status, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (message_id) DO UPDATE SET
+			type = CASE WHEN EXCLUDED.type != 'message' THEN EXCLUDED.type ELSE messages.type END,
+			updated_at = EXCLUDED.updated_at`,
+		msg.MessageID, msg.Protocol, string(msg.Type), string(msg.Status),
+		msg.CreatedAt, msg.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upserting message: %w", err)
+	}
+
+	// Upsert message_sources table
+	_, err = tx.Exec(ctx, `
+		INSERT INTO message_sources (message_id, chain_id, tx_hash, block_number, timestamp, sender, log_index)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (message_id) DO NOTHING`,
+		msg.MessageID, msg.Source.ChainID, msg.Source.TxHash,
+		msg.Source.BlockNumber, msg.Source.Timestamp, msg.Source.Sender, msg.Source.LogIndex,
+	)
+	if err != nil {
+		return fmt.Errorf("upserting message source: %w", err)
+	}
+
+	// Upsert message_payloads table
+	if msg.Payload != nil {
+		_, err = tx.Exec(ctx, `
+			INSERT INTO message_payloads (message_id, token, amount, data, nonce)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (message_id) DO UPDATE SET
+				token = COALESCE(NULLIF(EXCLUDED.token, ''), message_payloads.token),
+				amount = COALESCE(NULLIF(EXCLUDED.amount, ''), message_payloads.amount),
+				data = COALESCE(NULLIF(EXCLUDED.data, ''), message_payloads.data)`,
+			msg.MessageID, msg.Payload.Token, msg.Payload.Amount,
+			msg.Payload.Data, msg.Payload.Nonce,
+		)
+		if err != nil {
+			return fmt.Errorf("upserting message payload: %w", err)
+		}
+	}
+
+	// Upsert message_metadata table
+	if msg.Metadata != nil {
+		_, err = tx.Exec(ctx, `
+			INSERT INTO message_metadata (message_id, fee, relayer, gas_used, latency_seconds)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (message_id) DO NOTHING`,
+			msg.MessageID, msg.Metadata.Fee, msg.Metadata.Relayer,
+			msg.Metadata.GasUsed, msg.Metadata.LatencySeconds,
+		)
+		if err != nil {
+			return fmt.Errorf("upserting message metadata: %w", err)
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+// FindByCorrelationKey looks up an existing pending message by composite key.
+func (s *PostgresMessageStore) FindByCorrelationKey(ctx context.Context, key *normalizer.CorrelationKey) (*types.Message, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT m.message_id, m.protocol, m.type, m.status, m.created_at, m.updated_at,
+		       s.chain_id, s.tx_hash, s.block_number, s.timestamp, s.sender, s.log_index,
+		       p.token, p.amount, p.data, p.nonce
+		FROM messages m
+		JOIN message_sources s ON m.message_id = s.message_id
+		JOIN message_payloads p ON m.message_id = p.message_id
+		WHERE m.protocol = $1
+		  AND p.nonce = $2
+		  AND s.sender = $3
+		  AND s.chain_id = $4
+		  AND m.status = 'pending'
+		LIMIT 1`,
+		key.Protocol, key.Nonce, key.Sender, key.SrcChainID,
+	)
+
+	msg := &types.Message{
+		Payload: &types.Payload{},
+	}
+	var msgType, msgStatus string
+	var token, amount, data *string
+
+	err := row.Scan(
+		&msg.MessageID, &msg.Protocol, &msgType, &msgStatus, &msg.CreatedAt, &msg.UpdatedAt,
+		&msg.Source.ChainID, &msg.Source.TxHash, &msg.Source.BlockNumber,
+		&msg.Source.Timestamp, &msg.Source.Sender, &msg.Source.LogIndex,
+		&token, &amount, &data, &msg.Payload.Nonce,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying by correlation key: %w", err)
+	}
+
+	msg.Type = types.MessageType(msgType)
+	msg.Status = types.MessageStatus(msgStatus)
+	if token != nil {
+		msg.Payload.Token = *token
+	}
+	if amount != nil {
+		msg.Payload.Amount = *amount
+	}
+	if data != nil {
+		msg.Payload.Data = *data
+	}
+
+	return msg, nil
+}
+
+// UpdateDestination sets the destination details and updates the message status.
+func (s *PostgresMessageStore) UpdateDestination(ctx context.Context, messageID string, dest *types.Destination, status types.MessageStatus) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Upsert destination
+	_, err = tx.Exec(ctx, `
+		INSERT INTO message_destinations (message_id, chain_id, tx_hash, block_number, timestamp, receiver, log_index)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (message_id) DO UPDATE SET
+			chain_id = EXCLUDED.chain_id,
+			tx_hash = EXCLUDED.tx_hash,
+			block_number = EXCLUDED.block_number,
+			timestamp = EXCLUDED.timestamp,
+			receiver = EXCLUDED.receiver,
+			log_index = EXCLUDED.log_index`,
+		messageID, dest.ChainID, dest.TxHash, dest.BlockNumber,
+		dest.Timestamp, dest.Receiver, dest.LogIndex,
+	)
+	if err != nil {
+		return fmt.Errorf("upserting destination: %w", err)
+	}
+
+	// Update message status
+	_, err = tx.Exec(ctx, `
+		UPDATE messages SET status = $2, updated_at = NOW() WHERE message_id = $1`,
+		messageID, string(status),
+	)
+	if err != nil {
+		return fmt.Errorf("updating message status: %w", err)
+	}
+
+	// Compute and store latency when both timestamps are available
+	if dest.Timestamp > 0 {
+		_, err = tx.Exec(ctx, `
+			UPDATE message_metadata SET latency_seconds = ($2 - s.timestamp)
+			FROM message_sources s
+			WHERE message_metadata.message_id = $1
+			  AND s.message_id = $1
+			  AND s.timestamp > 0`,
+			messageID, dest.Timestamp,
+		)
+		if err != nil {
+			return fmt.Errorf("updating latency: %w", err)
+		}
+	}
+
+	return tx.Commit(ctx)
+}

--- a/internal/indexer/message_store_test.go
+++ b/internal/indexer/message_store_test.go
@@ -1,0 +1,355 @@
+package indexer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/normalizer"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/storage/postgres"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/types"
+)
+
+const testDSN = "postgres://postgres:password@localhost:5432/crosschain_test?sslmode=disable"
+
+func newTestMessageStore(t *testing.T) *PostgresMessageStore {
+	t.Helper()
+	ctx := context.Background()
+	pool, err := postgres.NewPool(ctx, testDSN)
+	if err != nil {
+		t.Skip("Skipping test: PostgreSQL not available:", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	return NewPostgresMessageStore(pool)
+}
+
+func cleanupMessage(t *testing.T, store *PostgresMessageStore, messageID string) {
+	t.Helper()
+	ctx := context.Background()
+	// Delete in order respecting foreign keys (CASCADE handles this, but be explicit)
+	store.pool.Exec(ctx, "DELETE FROM messages WHERE message_id = $1", messageID)
+}
+
+func newTestMessage(messageID string) *types.Message {
+	now := time.Now()
+	return &types.Message{
+		MessageID: messageID,
+		Protocol:  "layerzero_v2",
+		Type:      types.TypeMessage,
+		Status:    types.StatusPending,
+		Source: types.Source{
+			ChainID:     1,
+			TxHash:      "0xabc123",
+			BlockNumber: 19000000,
+			Timestamp:   1706000000,
+			Sender:      "0xSender1111111111111111111111111111111111",
+			LogIndex:    5,
+		},
+		Payload: &types.Payload{
+			Data:  "0xdeadbeef",
+			Nonce: 42,
+		},
+		Metadata:  &types.Metadata{},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func TestPostgresMessageStore_UpsertMessage(t *testing.T) {
+	store := newTestMessageStore(t)
+	ctx := context.Background()
+	msgID := "test-upsert-0x1234"
+	t.Cleanup(func() { cleanupMessage(t, store, msgID) })
+
+	msg := newTestMessage(msgID)
+	err := store.UpsertMessage(ctx, msg)
+	if err != nil {
+		t.Fatalf("UpsertMessage failed: %v", err)
+	}
+
+	// Verify message exists
+	var status string
+	err = store.pool.QueryRow(ctx, "SELECT status FROM messages WHERE message_id = $1", msgID).Scan(&status)
+	if err != nil {
+		t.Fatalf("failed to query message: %v", err)
+	}
+	if status != "pending" {
+		t.Errorf("expected status pending, got %s", status)
+	}
+
+	// Verify source exists
+	var chainID int64
+	err = store.pool.QueryRow(ctx, "SELECT chain_id FROM message_sources WHERE message_id = $1", msgID).Scan(&chainID)
+	if err != nil {
+		t.Fatalf("failed to query source: %v", err)
+	}
+	if chainID != 1 {
+		t.Errorf("expected chain_id 1, got %d", chainID)
+	}
+
+	// Verify payload exists
+	var nonce int64
+	err = store.pool.QueryRow(ctx, "SELECT nonce FROM message_payloads WHERE message_id = $1", msgID).Scan(&nonce)
+	if err != nil {
+		t.Fatalf("failed to query payload: %v", err)
+	}
+	if nonce != 42 {
+		t.Errorf("expected nonce 42, got %d", nonce)
+	}
+}
+
+func TestPostgresMessageStore_UpsertMessage_Idempotent(t *testing.T) {
+	store := newTestMessageStore(t)
+	ctx := context.Background()
+	msgID := "test-idempotent-0x5678"
+	t.Cleanup(func() { cleanupMessage(t, store, msgID) })
+
+	msg := newTestMessage(msgID)
+
+	// Insert twice
+	if err := store.UpsertMessage(ctx, msg); err != nil {
+		t.Fatalf("first UpsertMessage failed: %v", err)
+	}
+	if err := store.UpsertMessage(ctx, msg); err != nil {
+		t.Fatalf("second UpsertMessage failed: %v", err)
+	}
+
+	// Should still be one row
+	var count int
+	err := store.pool.QueryRow(ctx, "SELECT COUNT(*) FROM messages WHERE message_id = $1", msgID).Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 message, got %d", count)
+	}
+}
+
+func TestPostgresMessageStore_UpsertMessage_OFTUpgradesType(t *testing.T) {
+	store := newTestMessageStore(t)
+	ctx := context.Background()
+	msgID := "test-type-upgrade-0xabcd"
+	t.Cleanup(func() { cleanupMessage(t, store, msgID) })
+
+	// First insert as message type (from PacketSent)
+	msg := newTestMessage(msgID)
+	if err := store.UpsertMessage(ctx, msg); err != nil {
+		t.Fatalf("first UpsertMessage failed: %v", err)
+	}
+
+	// Second insert as token_transfer type (from OFTSent)
+	msg.Type = types.TypeTokenTransfer
+	msg.Payload.Amount = "1000000"
+	if err := store.UpsertMessage(ctx, msg); err != nil {
+		t.Fatalf("second UpsertMessage failed: %v", err)
+	}
+
+	// Type should be upgraded to token_transfer
+	var msgType string
+	err := store.pool.QueryRow(ctx, "SELECT type FROM messages WHERE message_id = $1", msgID).Scan(&msgType)
+	if err != nil {
+		t.Fatalf("failed to query type: %v", err)
+	}
+	if msgType != "token_transfer" {
+		t.Errorf("expected type token_transfer, got %s", msgType)
+	}
+}
+
+func TestPostgresMessageStore_FindByCorrelationKey_Found(t *testing.T) {
+	store := newTestMessageStore(t)
+	ctx := context.Background()
+	msgID := "test-find-0x9999"
+	t.Cleanup(func() { cleanupMessage(t, store, msgID) })
+
+	msg := newTestMessage(msgID)
+	if err := store.UpsertMessage(ctx, msg); err != nil {
+		t.Fatalf("UpsertMessage failed: %v", err)
+	}
+
+	key := &normalizer.CorrelationKey{
+		Protocol:   "layerzero_v2",
+		Nonce:      42,
+		Sender:     "0xSender1111111111111111111111111111111111",
+		SrcChainID: 1,
+	}
+
+	found, err := store.FindByCorrelationKey(ctx, key)
+	if err != nil {
+		t.Fatalf("FindByCorrelationKey failed: %v", err)
+	}
+	if found == nil {
+		t.Fatal("expected to find message, got nil")
+	}
+	if found.MessageID != msgID {
+		t.Errorf("expected message_id %s, got %s", msgID, found.MessageID)
+	}
+}
+
+func TestPostgresMessageStore_FindByCorrelationKey_NotFound(t *testing.T) {
+	store := newTestMessageStore(t)
+	ctx := context.Background()
+
+	key := &normalizer.CorrelationKey{
+		Protocol:   "layerzero_v2",
+		Nonce:      999999,
+		Sender:     "0xNonExistent",
+		SrcChainID: 1,
+	}
+
+	found, err := store.FindByCorrelationKey(ctx, key)
+	if err != nil {
+		t.Fatalf("FindByCorrelationKey failed: %v", err)
+	}
+	if found != nil {
+		t.Errorf("expected nil, got message %s", found.MessageID)
+	}
+}
+
+func TestPostgresMessageStore_FindByCorrelationKey_OnlyPending(t *testing.T) {
+	store := newTestMessageStore(t)
+	ctx := context.Background()
+	msgID := "test-only-pending-0xaaaa"
+	t.Cleanup(func() { cleanupMessage(t, store, msgID) })
+
+	msg := newTestMessage(msgID)
+	if err := store.UpsertMessage(ctx, msg); err != nil {
+		t.Fatalf("UpsertMessage failed: %v", err)
+	}
+
+	// Mark as executed
+	_, err := store.pool.Exec(ctx, "UPDATE messages SET status = 'executed' WHERE message_id = $1", msgID)
+	if err != nil {
+		t.Fatalf("failed to update status: %v", err)
+	}
+
+	key := &normalizer.CorrelationKey{
+		Protocol:   "layerzero_v2",
+		Nonce:      42,
+		Sender:     "0xSender1111111111111111111111111111111111",
+		SrcChainID: 1,
+	}
+
+	found, err := store.FindByCorrelationKey(ctx, key)
+	if err != nil {
+		t.Fatalf("FindByCorrelationKey failed: %v", err)
+	}
+	if found != nil {
+		t.Error("expected nil for executed message, but found one")
+	}
+}
+
+func TestPostgresMessageStore_UpdateDestination(t *testing.T) {
+	store := newTestMessageStore(t)
+	ctx := context.Background()
+	msgID := "test-update-dest-0xbbbb"
+	t.Cleanup(func() { cleanupMessage(t, store, msgID) })
+
+	msg := newTestMessage(msgID)
+	if err := store.UpsertMessage(ctx, msg); err != nil {
+		t.Fatalf("UpsertMessage failed: %v", err)
+	}
+
+	dest := &types.Destination{
+		ChainID:     42161,
+		TxHash:      "0xdef456",
+		BlockNumber: 180000000,
+		Timestamp:   1706000045,
+		Receiver:    "0xReceiver2222222222222222222222222222222222",
+		LogIndex:    3,
+	}
+
+	err := store.UpdateDestination(ctx, msgID, dest, types.StatusExecuted)
+	if err != nil {
+		t.Fatalf("UpdateDestination failed: %v", err)
+	}
+
+	// Verify status updated
+	var status string
+	err = store.pool.QueryRow(ctx, "SELECT status FROM messages WHERE message_id = $1", msgID).Scan(&status)
+	if err != nil {
+		t.Fatalf("failed to query status: %v", err)
+	}
+	if status != "executed" {
+		t.Errorf("expected status executed, got %s", status)
+	}
+
+	// Verify destination exists
+	var destChainID int64
+	err = store.pool.QueryRow(ctx, "SELECT chain_id FROM message_destinations WHERE message_id = $1", msgID).Scan(&destChainID)
+	if err != nil {
+		t.Fatalf("failed to query destination: %v", err)
+	}
+	if destChainID != 42161 {
+		t.Errorf("expected dest chain_id 42161, got %d", destChainID)
+	}
+
+	// Verify latency computed (45 seconds = 1706000045 - 1706000000)
+	var latency int64
+	err = store.pool.QueryRow(ctx, "SELECT latency_seconds FROM message_metadata WHERE message_id = $1", msgID).Scan(&latency)
+	if err != nil {
+		t.Fatalf("failed to query latency: %v", err)
+	}
+	if latency != 45 {
+		t.Errorf("expected latency 45, got %d", latency)
+	}
+}
+
+func TestPostgresMessageStore_FullCorrelationFlow(t *testing.T) {
+	store := newTestMessageStore(t)
+	ctx := context.Background()
+	msgID := "test-full-flow-0xcccc"
+	t.Cleanup(func() { cleanupMessage(t, store, msgID) })
+
+	// Step 1: PacketSent creates pending message
+	msg := newTestMessage(msgID)
+	if err := store.UpsertMessage(ctx, msg); err != nil {
+		t.Fatalf("UpsertMessage failed: %v", err)
+	}
+
+	// Step 2: Find by correlation key
+	key := &normalizer.CorrelationKey{
+		Protocol:   "layerzero_v2",
+		Nonce:      42,
+		Sender:     "0xSender1111111111111111111111111111111111",
+		SrcChainID: 1,
+	}
+	found, err := store.FindByCorrelationKey(ctx, key)
+	if err != nil {
+		t.Fatalf("FindByCorrelationKey failed: %v", err)
+	}
+	if found == nil {
+		t.Fatal("expected to find pending message")
+	}
+
+	// Step 3: PacketReceived updates destination
+	dest := &types.Destination{
+		ChainID:     42161,
+		TxHash:      "0xdef456",
+		BlockNumber: 180000000,
+		Timestamp:   1706000045,
+		Receiver:    "0xReceiver",
+		LogIndex:    3,
+	}
+	if err := store.UpdateDestination(ctx, found.MessageID, dest, types.StatusExecuted); err != nil {
+		t.Fatalf("UpdateDestination failed: %v", err)
+	}
+
+	// Step 4: Verify final state
+	var status string
+	err = store.pool.QueryRow(ctx, "SELECT status FROM messages WHERE message_id = $1", msgID).Scan(&status)
+	if err != nil {
+		t.Fatalf("failed to query final status: %v", err)
+	}
+	if status != "executed" {
+		t.Errorf("expected final status executed, got %s", status)
+	}
+
+	// Verify can no longer find by correlation key (no longer pending)
+	found, err = store.FindByCorrelationKey(ctx, key)
+	if err != nil {
+		t.Fatalf("second FindByCorrelationKey failed: %v", err)
+	}
+	if found != nil {
+		t.Error("expected nil after message is executed")
+	}
+}

--- a/internal/indexer/processor.go
+++ b/internal/indexer/processor.go
@@ -9,11 +9,12 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/chain"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/correlator"
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder"
 )
 
 // ProcessChain runs the indexing loop for a single chain and protocol combination.
-// It continuously fetches, decodes, and processes events from the specified chain.
+// It continuously fetches, decodes, normalizes, and correlates events from the specified chain.
 func ProcessChain(
 	ctx context.Context,
 	chainID uint64,
@@ -21,6 +22,7 @@ func ProcessChain(
 	dec decoder.Decoder,
 	chainClient *chain.Client,
 	cursors CursorStore,
+	corr *correlator.Correlator,
 	batchSize uint64,
 	pollInterval time.Duration,
 	log zerolog.Logger,
@@ -122,6 +124,9 @@ func ProcessChain(
 			Uint64("to", toBlock).
 			Msg("Fetched logs")
 
+		// Cache block timestamps to avoid redundant RPC calls within a batch
+		blockTimestamps := make(map[uint64]int64)
+
 		// Process each log
 		for _, ethLog := range logs {
 			// Decode the log
@@ -135,14 +140,34 @@ func ProcessChain(
 				continue
 			}
 
-			// For now, just log the decoded event
-			// In Issue #16, this will be normalized and stored in the database
+			// Enrich with block timestamp
+			if _, cached := blockTimestamps[rawEvent.BlockNumber]; !cached {
+				ts, err := chainClient.BlockTimestamp(ctx, rawEvent.BlockNumber)
+				if err != nil {
+					log.Warn().Err(err).Uint64("block", rawEvent.BlockNumber).Msg("Failed to get block timestamp")
+				} else {
+					blockTimestamps[rawEvent.BlockNumber] = ts
+				}
+			}
+			rawEvent.Timestamp = blockTimestamps[rawEvent.BlockNumber]
+
+			// Normalize and correlate the event
+			if err := corr.Process(ctx, rawEvent); err != nil {
+				log.Warn().
+					Err(err).
+					Str("event_type", rawEvent.EventType).
+					Str("tx_hash", rawEvent.TxHash).
+					Uint("log_index", rawEvent.LogIndex).
+					Msg("Failed to process event, skipping")
+				continue
+			}
+
 			log.Info().
 				Str("event_type", rawEvent.EventType).
 				Str("tx_hash", rawEvent.TxHash).
 				Uint("log_index", rawEvent.LogIndex).
 				Uint64("block_number", rawEvent.BlockNumber).
-				Msg("Decoded event")
+				Msg("Processed event")
 		}
 
 		// Update cursor to end of batch

--- a/internal/normalizer/normalizer.go
+++ b/internal/normalizer/normalizer.go
@@ -1,0 +1,172 @@
+package normalizer
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/types"
+)
+
+// Result represents the outcome of normalizing a RawEvent.
+type Result struct {
+	// Message is the normalized message. For source events (PacketSent, OFTSent),
+	// this is a complete message. For destination events (PacketReceived), this
+	// contains only the Destination field for correlation.
+	Message *types.Message
+
+	// IsCorrelation indicates this event should update an existing message
+	// rather than create a new one. True for PacketReceived events.
+	IsCorrelation bool
+
+	// CorrelationKey holds the fields for matching to an existing pending message.
+	// Only set when IsCorrelation is true.
+	CorrelationKey *CorrelationKey
+}
+
+// CorrelationKey contains the fields needed to find an existing pending message
+// for PacketReceived correlation. LayerZero PacketReceived events do not include
+// a GUID, so we match by (protocol, nonce, sender, src_chain_id).
+type CorrelationKey struct {
+	Protocol   string
+	Nonce      uint64
+	Sender     string
+	SrcChainID uint64
+}
+
+// Normalize converts a decoder.RawEvent into a normalizer.Result.
+func Normalize(event *decoder.RawEvent) (*Result, error) {
+	if event == nil {
+		return nil, fmt.Errorf("nil event")
+	}
+
+	switch event.EventType {
+	case "PacketSent":
+		return normalizePacketSent(event)
+	case "PacketReceived":
+		return normalizePacketReceived(event)
+	case "OFTSent":
+		return normalizeOFTSent(event)
+	default:
+		return nil, fmt.Errorf("unsupported event type: %s", event.EventType)
+	}
+}
+
+// normalizePacketSent creates a new pending message from a PacketSent event.
+func normalizePacketSent(event *decoder.RawEvent) (*Result, error) {
+	guid := event.Data["guid"]
+	if guid == "" {
+		return nil, fmt.Errorf("PacketSent missing guid")
+	}
+
+	nonce, err := parseUint64(event.Data["nonce"])
+	if err != nil {
+		return nil, fmt.Errorf("PacketSent invalid nonce: %w", err)
+	}
+
+	now := time.Now()
+	msg := &types.Message{
+		MessageID: guid,
+		Protocol:  event.Protocol,
+		Type:      types.TypeMessage,
+		Status:    types.StatusPending,
+		Source: types.Source{
+			ChainID:     event.ChainID,
+			TxHash:      event.TxHash,
+			BlockNumber: event.BlockNumber,
+			Timestamp:   event.Timestamp,
+			Sender:      event.Data["sender"],
+			LogIndex:    event.LogIndex,
+		},
+		Payload: &types.Payload{
+			Data:  event.Data["message"],
+			Nonce: nonce,
+		},
+		Metadata:  &types.Metadata{},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	return &Result{Message: msg}, nil
+}
+
+// normalizePacketReceived creates a correlation result for matching an existing message.
+func normalizePacketReceived(event *decoder.RawEvent) (*Result, error) {
+	nonce, err := parseUint64(event.Data["nonce"])
+	if err != nil {
+		return nil, fmt.Errorf("PacketReceived invalid nonce: %w", err)
+	}
+
+	sender := event.Data["sender"]
+	if sender == "" {
+		return nil, fmt.Errorf("PacketReceived missing sender")
+	}
+
+	srcChainID, err := parseUint64(event.Data["src_chain_id"])
+	if err != nil {
+		return nil, fmt.Errorf("PacketReceived invalid src_chain_id: %w", err)
+	}
+
+	// The chain where PacketReceived is observed is the destination chain.
+	msg := &types.Message{
+		Destination: &types.Destination{
+			ChainID:     event.ChainID,
+			TxHash:      event.TxHash,
+			BlockNumber: event.BlockNumber,
+			Timestamp:   event.Timestamp,
+			Receiver:    event.Data["receiver"],
+			LogIndex:    event.LogIndex,
+		},
+	}
+
+	return &Result{
+		Message:       msg,
+		IsCorrelation: true,
+		CorrelationKey: &CorrelationKey{
+			Protocol:   event.Protocol,
+			Nonce:      nonce,
+			Sender:     sender,
+			SrcChainID: srcChainID,
+		},
+	}, nil
+}
+
+// normalizeOFTSent creates a token transfer message from an OFTSent event.
+func normalizeOFTSent(event *decoder.RawEvent) (*Result, error) {
+	guid := event.Data["guid"]
+	if guid == "" {
+		return nil, fmt.Errorf("OFTSent missing guid")
+	}
+
+	now := time.Now()
+	msg := &types.Message{
+		MessageID: guid,
+		Protocol:  event.Protocol,
+		Type:      types.TypeTokenTransfer,
+		Status:    types.StatusPending,
+		Source: types.Source{
+			ChainID:     event.ChainID,
+			TxHash:      event.TxHash,
+			BlockNumber: event.BlockNumber,
+			Timestamp:   event.Timestamp,
+			Sender:      event.Data["from_address"],
+			LogIndex:    event.LogIndex,
+		},
+		Payload: &types.Payload{
+			Amount: event.Data["amount_sent"],
+		},
+		Metadata:  &types.Metadata{},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	return &Result{Message: msg}, nil
+}
+
+func parseUint64(s string) (uint64, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty string")
+	}
+	return strconv.ParseUint(s, 10, 64)
+}

--- a/internal/normalizer/normalizer_test.go
+++ b/internal/normalizer/normalizer_test.go
@@ -1,0 +1,309 @@
+package normalizer
+
+import (
+	"testing"
+
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/types"
+)
+
+func newPacketSentEvent() *decoder.RawEvent {
+	return &decoder.RawEvent{
+		Protocol:    "layerzero_v2",
+		ChainID:     1,
+		BlockNumber: 19000000,
+		TxHash:      "0xabc123",
+		LogIndex:    5,
+		Timestamp:   1706000000,
+		EventType:   "PacketSent",
+		Data: map[string]string{
+			"guid":         "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			"nonce":        "42",
+			"sender":       "0xSender1111111111111111111111111111111111",
+			"receiver":     "0xReceiver2222222222222222222222222222222222",
+			"src_eid":      "30101",
+			"src_chain_id": "1",
+			"dst_eid":      "30110",
+			"dst_chain_id": "42161",
+			"message":      "0xdeadbeef",
+			"version":      "1",
+		},
+	}
+}
+
+func newPacketReceivedEvent() *decoder.RawEvent {
+	return &decoder.RawEvent{
+		Protocol:    "layerzero_v2",
+		ChainID:     42161,
+		BlockNumber: 180000000,
+		TxHash:      "0xdef456",
+		LogIndex:    3,
+		Timestamp:   1706000045,
+		EventType:   "PacketReceived",
+		Data: map[string]string{
+			"nonce":        "42",
+			"sender":       "0xSender1111111111111111111111111111111111",
+			"receiver":     "0xReceiver2222222222222222222222222222222222",
+			"src_eid":      "30101",
+			"src_chain_id": "1",
+		},
+	}
+}
+
+func newOFTSentEvent() *decoder.RawEvent {
+	return &decoder.RawEvent{
+		Protocol:    "layerzero_v2",
+		ChainID:     1,
+		BlockNumber: 19000000,
+		TxHash:      "0xabc123",
+		LogIndex:    6,
+		Timestamp:   1706000000,
+		EventType:   "OFTSent",
+		Data: map[string]string{
+			"guid":            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			"from_address":    "0xSender1111111111111111111111111111111111",
+			"dst_eid":         "30110",
+			"dst_chain_id":    "42161",
+			"amount_sent":     "1000000000",
+			"amount_received": "999000000",
+		},
+	}
+}
+
+func TestNormalizePacketSent_BasicFields(t *testing.T) {
+	event := newPacketSentEvent()
+	result, err := Normalize(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.IsCorrelation {
+		t.Error("PacketSent should not be a correlation event")
+	}
+
+	msg := result.Message
+	if msg.MessageID != event.Data["guid"] {
+		t.Errorf("expected MessageID %s, got %s", event.Data["guid"], msg.MessageID)
+	}
+	if msg.Protocol != "layerzero_v2" {
+		t.Errorf("expected protocol layerzero_v2, got %s", msg.Protocol)
+	}
+	if msg.Type != types.TypeMessage {
+		t.Errorf("expected type message, got %s", msg.Type)
+	}
+	if msg.Status != types.StatusPending {
+		t.Errorf("expected status pending, got %s", msg.Status)
+	}
+}
+
+func TestNormalizePacketSent_SourceFields(t *testing.T) {
+	event := newPacketSentEvent()
+	result, err := Normalize(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	src := result.Message.Source
+	if src.ChainID != 1 {
+		t.Errorf("expected chain_id 1, got %d", src.ChainID)
+	}
+	if src.TxHash != "0xabc123" {
+		t.Errorf("expected tx_hash 0xabc123, got %s", src.TxHash)
+	}
+	if src.BlockNumber != 19000000 {
+		t.Errorf("expected block_number 19000000, got %d", src.BlockNumber)
+	}
+	if src.Timestamp != 1706000000 {
+		t.Errorf("expected timestamp 1706000000, got %d", src.Timestamp)
+	}
+	if src.Sender != "0xSender1111111111111111111111111111111111" {
+		t.Errorf("expected sender 0xSender..., got %s", src.Sender)
+	}
+	if src.LogIndex != 5 {
+		t.Errorf("expected log_index 5, got %d", src.LogIndex)
+	}
+}
+
+func TestNormalizePacketSent_PayloadFields(t *testing.T) {
+	event := newPacketSentEvent()
+	result, err := Normalize(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	payload := result.Message.Payload
+	if payload == nil {
+		t.Fatal("expected payload to be set")
+	}
+	if payload.Nonce != 42 {
+		t.Errorf("expected nonce 42, got %d", payload.Nonce)
+	}
+	if payload.Data != "0xdeadbeef" {
+		t.Errorf("expected data 0xdeadbeef, got %s", payload.Data)
+	}
+}
+
+func TestNormalizePacketSent_NoDestination(t *testing.T) {
+	event := newPacketSentEvent()
+	result, err := Normalize(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Message.Destination != nil {
+		t.Error("PacketSent should not have a destination")
+	}
+}
+
+func TestNormalizePacketSent_MissingGUID(t *testing.T) {
+	event := newPacketSentEvent()
+	delete(event.Data, "guid")
+
+	_, err := Normalize(event)
+	if err == nil {
+		t.Fatal("expected error for missing guid")
+	}
+}
+
+func TestNormalizePacketSent_InvalidNonce(t *testing.T) {
+	event := newPacketSentEvent()
+	event.Data["nonce"] = "not-a-number"
+
+	_, err := Normalize(event)
+	if err == nil {
+		t.Fatal("expected error for invalid nonce")
+	}
+}
+
+func TestNormalizePacketReceived_CorrelationKey(t *testing.T) {
+	event := newPacketReceivedEvent()
+	result, err := Normalize(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.IsCorrelation {
+		t.Error("PacketReceived should be a correlation event")
+	}
+
+	key := result.CorrelationKey
+	if key == nil {
+		t.Fatal("expected correlation key to be set")
+	}
+	if key.Protocol != "layerzero_v2" {
+		t.Errorf("expected protocol layerzero_v2, got %s", key.Protocol)
+	}
+	if key.Nonce != 42 {
+		t.Errorf("expected nonce 42, got %d", key.Nonce)
+	}
+	if key.Sender != "0xSender1111111111111111111111111111111111" {
+		t.Errorf("expected sender 0xSender..., got %s", key.Sender)
+	}
+	if key.SrcChainID != 1 {
+		t.Errorf("expected src_chain_id 1, got %d", key.SrcChainID)
+	}
+}
+
+func TestNormalizePacketReceived_DestinationFields(t *testing.T) {
+	event := newPacketReceivedEvent()
+	result, err := Normalize(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dest := result.Message.Destination
+	if dest == nil {
+		t.Fatal("expected destination to be set")
+	}
+	if dest.ChainID != 42161 {
+		t.Errorf("expected chain_id 42161, got %d", dest.ChainID)
+	}
+	if dest.TxHash != "0xdef456" {
+		t.Errorf("expected tx_hash 0xdef456, got %s", dest.TxHash)
+	}
+	if dest.BlockNumber != 180000000 {
+		t.Errorf("expected block_number 180000000, got %d", dest.BlockNumber)
+	}
+	if dest.Timestamp != 1706000045 {
+		t.Errorf("expected timestamp 1706000045, got %d", dest.Timestamp)
+	}
+	if dest.Receiver != "0xReceiver2222222222222222222222222222222222" {
+		t.Errorf("expected receiver 0xReceiver..., got %s", dest.Receiver)
+	}
+}
+
+func TestNormalizePacketReceived_MissingSender(t *testing.T) {
+	event := newPacketReceivedEvent()
+	delete(event.Data, "sender")
+
+	_, err := Normalize(event)
+	if err == nil {
+		t.Fatal("expected error for missing sender")
+	}
+}
+
+func TestNormalizeOFTSent_TokenTransferType(t *testing.T) {
+	event := newOFTSentEvent()
+	result, err := Normalize(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.IsCorrelation {
+		t.Error("OFTSent should not be a correlation event")
+	}
+
+	msg := result.Message
+	if msg.Type != types.TypeTokenTransfer {
+		t.Errorf("expected type token_transfer, got %s", msg.Type)
+	}
+	if msg.MessageID != event.Data["guid"] {
+		t.Errorf("expected MessageID %s, got %s", event.Data["guid"], msg.MessageID)
+	}
+}
+
+func TestNormalizeOFTSent_AmountFields(t *testing.T) {
+	event := newOFTSentEvent()
+	result, err := Normalize(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	payload := result.Message.Payload
+	if payload == nil {
+		t.Fatal("expected payload to be set")
+	}
+	if payload.Amount != "1000000000" {
+		t.Errorf("expected amount 1000000000, got %s", payload.Amount)
+	}
+}
+
+func TestNormalizeOFTSent_SenderIsFromAddress(t *testing.T) {
+	event := newOFTSentEvent()
+	result, err := Normalize(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Message.Source.Sender != "0xSender1111111111111111111111111111111111" {
+		t.Errorf("expected sender from from_address, got %s", result.Message.Source.Sender)
+	}
+}
+
+func TestNormalize_UnknownEventType(t *testing.T) {
+	event := &decoder.RawEvent{
+		EventType: "UnknownEvent",
+		Data:      map[string]string{},
+	}
+	_, err := Normalize(event)
+	if err == nil {
+		t.Fatal("expected error for unknown event type")
+	}
+}
+
+func TestNormalize_NilEvent(t *testing.T) {
+	_, err := Normalize(nil)
+	if err == nil {
+		t.Fatal("expected error for nil event")
+	}
+}

--- a/migrations/000002_add_correlation_index.down.sql
+++ b/migrations/000002_add_correlation_index.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS idx_message_sources_sender_chain;
+DROP INDEX IF EXISTS idx_message_payloads_nonce;
+
+COMMIT;

--- a/migrations/000002_add_correlation_index.up.sql
+++ b/migrations/000002_add_correlation_index.up.sql
@@ -1,0 +1,11 @@
+-- Add indexes to support efficient PacketReceived correlation lookups.
+-- Correlation uses (protocol, nonce, sender, src_chain_id) to match
+-- PacketReceived events to existing pending messages.
+
+BEGIN;
+
+CREATE INDEX idx_message_payloads_nonce ON message_payloads(nonce);
+
+CREATE INDEX idx_message_sources_sender_chain ON message_sources(sender, chain_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Add normalizer to map LayerZero `RawEvent` (`PacketSent`, `PacketReceived`, `OFTSent`) to a unified `Message` schema
- Add correlator that creates `pending` messages on `PacketSent` and updates them to `executed` on `PacketReceived` with latency computation
- Add PostgreSQL `MessageStore` with upsert logic across all 5 message tables (`messages`, `message_sources`, `message_destinations`, `message_payloads`, `message_metadata`)
- Add correlation index migration for efficient composite-key lookups
- Integrate correlator into the indexing loop with block timestamp enrichment

Closes #16

## Test plan
- [x] Verify normalizer unit tests pass (14 tests covering all event types and error cases)
- [x] Verify correlator unit tests pass (7 tests with mock store)
- [x] Verify PostgreSQL message store tests pass against a local database (8 tests including full correlation flow)
- [x] Run migration `000002_add_correlation_index` and confirm indexes are created
- [ ] End-to-end: index a chain with LayerZero activity and confirm `pending` → `executed` transitions in the database (todo::requires manual verification with live RPC endpoints)

## Summary by Sourcery

Integrate a normalization and correlation pipeline for LayerZero events into the indexer, persisting cross-chain messages in PostgreSQL with latency tracking.

New Features:
- Normalize LayerZero PacketSent, PacketReceived, and OFTSent raw events into a unified message schema with correlation keys for matching.
- Introduce a correlator component that links source and destination events into pending and executed messages with status transitions.
- Add a PostgreSQL-backed message store for messages, sources, destinations, payloads, and metadata, including GUID-based upserts and latency computation.
- Expose block timestamp retrieval in the chain client and enrich decoded events with timestamps during indexing.

Enhancements:
- Wire the correlator into the indexing loop so processed events are normalized, correlated, and stored instead of only logged.
- Add composite database indexes to support efficient correlation lookups over nonce, sender, and source chain.

Tests:
- Add unit tests for the normalizer covering all supported event types and error conditions.
- Add unit tests for the correlator’s behavior across successful correlations, missing matches, and error paths using a mock store.
- Add PostgreSQL integration tests for the message store, including idempotent upserts, type upgrades, correlation queries, destination updates, and full end-to-end correlation flow.