### PR TITLE
M3 implement ccip decode

### DIFF
--- a/cmd/indexer/main.go
+++ b/cmd/indexer/main.go
@@ -11,14 +11,13 @@ import (
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/config"
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder"
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder/axelar"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder/ccip"
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder/layerzero"
+	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder/wormhole"
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/indexer"
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/logger"
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/storage/akave"
 	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/storage/postgres"
-	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder/wormhole"
-	"github.com/Patrick-Ehimen/akave-crosschain-archive/internal/decoder/ccip"
-
 )
 
 func main() {
@@ -84,7 +83,7 @@ func main() {
 
 	ccipDecoder := ccip.NewCCIPDecoder()
 	if err := registry.Register(ccipDecoder); err != nil {
-    	log.Fatal().Err(err).Msg("Failed to register CCIP decoder")
+		log.Fatal().Err(err).Msg("Failed to register CCIP decoder")
 	}
 
 	log.Info().Strs("protocols", registry.Protocols()).Msg("Decoder registry initialized")

--- a/internal/correlator/correlator.go
+++ b/internal/correlator/correlator.go
@@ -65,14 +65,22 @@ func (c *Correlator) correlate(ctx context.Context, event *decoder.RawEvent, res
 		return nil
 	}
 
-	err = c.store.UpdateDestination(ctx, existing.MessageID, result.Message.Destination, types.StatusExecuted)
+	// Use the status from the normalizer result if set (e.g. CCIP StatusFailed),
+	// otherwise default to StatusExecuted for backward compatibility with protocols
+	// that don't set status on correlation results (LayerZero, Axelar, Wormhole).
+	status := result.Message.Status
+	if status == "" {
+		status = types.StatusExecuted
+	}
+
+	err = c.store.UpdateDestination(ctx, existing.MessageID, result.Message.Destination, status)
 	if err != nil {
 		return fmt.Errorf("updating destination for message %s: %w", existing.MessageID, err)
 	}
 
 	c.log.Info().
 		Str("message_id", existing.MessageID).
-		Str("status", string(types.StatusExecuted)).
+		Str("status", string(status)).
 		Msg("Correlated destination event with existing message")
 
 	return nil

--- a/internal/correlator/correlator_test.go
+++ b/internal/correlator/correlator_test.go
@@ -259,6 +259,117 @@ func TestProcess_PacketReceived_UpdateDestError(t *testing.T) {
 	}
 }
 
+func TestProcess_CCIPExecutionStateChanged_SuccessStatus(t *testing.T) {
+	existing := &types.Message{
+		MessageID: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+		Protocol:  "ccip",
+		Status:    types.StatusPending,
+	}
+	store := &mockMessageStore{findResult: existing}
+	c := newTestCorrelator(store)
+
+	event := &decoder.RawEvent{
+		Protocol:    "ccip",
+		ChainID:     42161,
+		BlockNumber: 210000000,
+		TxHash:      "0xccip333ccc",
+		LogIndex:    2,
+		Timestamp:   1708000090,
+		EventType:   "ExecutionStateChanged",
+		Data: map[string]string{
+			"message_id":      "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+			"sequence_number": "42",
+			"state":           "2",
+			"state_name":      "success",
+			"return_data":     "0x",
+		},
+	}
+
+	err := c.Process(context.Background(), event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if store.updateDestCall == nil {
+		t.Fatal("expected UpdateDestination to be called")
+	}
+	if store.updateDestCall.Status != types.StatusExecuted {
+		t.Errorf("expected status executed for state=2, got %s", store.updateDestCall.Status)
+	}
+}
+
+func TestProcess_CCIPExecutionStateChanged_FailureStatus(t *testing.T) {
+	existing := &types.Message{
+		MessageID: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		Protocol:  "ccip",
+		Status:    types.StatusPending,
+	}
+	store := &mockMessageStore{findResult: existing}
+	c := newTestCorrelator(store)
+
+	event := &decoder.RawEvent{
+		Protocol:    "ccip",
+		ChainID:     8453,
+		BlockNumber: 5100000,
+		TxHash:      "0xccip444ddd",
+		LogIndex:    9,
+		Timestamp:   1708000200,
+		EventType:   "ExecutionStateChanged",
+		Data: map[string]string{
+			"message_id":      "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			"sequence_number": "1",
+			"state":           "3",
+			"state_name":      "failure",
+			"return_data":     "0x08c379a0",
+		},
+	}
+
+	err := c.Process(context.Background(), event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if store.updateDestCall == nil {
+		t.Fatal("expected UpdateDestination to be called")
+	}
+	if store.updateDestCall.Status != types.StatusFailed {
+		t.Errorf("expected status failed for state=3, got %s", store.updateDestCall.Status)
+	}
+}
+
+func TestProcess_CCIPExecutionStateChanged_NonTerminalSkipped(t *testing.T) {
+	store := &mockMessageStore{}
+	c := newTestCorrelator(store)
+
+	event := &decoder.RawEvent{
+		Protocol:    "ccip",
+		ChainID:     42161,
+		BlockNumber: 210000000,
+		TxHash:      "0xccip555eee",
+		LogIndex:    1,
+		Timestamp:   1708000050,
+		EventType:   "ExecutionStateChanged",
+		Data: map[string]string{
+			"message_id":      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"sequence_number": "10",
+			"state":           "1",
+			"state_name":      "in_progress",
+			"return_data":     "0x",
+		},
+	}
+
+	// Non-terminal states (0, 1) should error during normalization
+	err := c.Process(context.Background(), event)
+	if err == nil {
+		t.Fatal("expected error for non-terminal execution state")
+	}
+
+	// Should NOT have called UpdateDestination
+	if store.updateDestCall != nil {
+		t.Error("expected UpdateDestination to NOT be called for non-terminal state")
+	}
+}
+
 func TestProcess_UnsupportedEventType(t *testing.T) {
 	store := &mockMessageStore{}
 	c := newTestCorrelator(store)

--- a/internal/decoder/ccip/decoder.go
+++ b/internal/decoder/ccip/decoder.go
@@ -26,14 +26,14 @@ const (
 //
 // Reference: https://docs.chain.link/ccip/supported-networks
 var ChainSelectorToEVM = map[uint64]uint64{
-	5009297550715157269:  1,     // Ethereum Mainnet
-	4949039107694359620:  42161, // Arbitrum One
-	3734403246176062136:  10,    // Optimism
-	15971525489660198786: 8453,  // Base
-	4051577828743386545:  137,   // Polygon
-	6433500567565415381:  43114, // Avalanche C-Chain
-	11344663589394136015: 56,    // BNB Smart Chain
-	6101244977088475029:  59144, // Linea
+	5009297550715157269:  1,      // Ethereum Mainnet
+	4949039107694359620:  42161,  // Arbitrum One
+	3734403246176062136:  10,     // Optimism
+	15971525489660198786: 8453,   // Base
+	4051577828743386545:  137,    // Polygon
+	6433500567565415381:  43114,  // Avalanche C-Chain
+	11344663589394136015: 56,     // BNB Smart Chain
+	6101244977088475029:  59144,  // Linea
 	1346049177634351622:  534352, // Scroll
 	// Testnets
 	16015286601757825753: 11155111, // Ethereum Sepolia
@@ -71,7 +71,7 @@ var OnRampAddresses = map[uint64][]common.Address{
 		common.HexToAddress("0xCe11020D56e5FDbfE46D9FC3021641FfbBB5AdEE"), // → Ethereum
 		common.HexToAddress("0x67761742ac8A21Ec4D76CA18cbd701e5A6F3Bef3"), // → Optimism
 		common.HexToAddress("0x2a86b4f6c56aFb06a3b1D7fB7aE36c0c68Bd5d3E"), // → Polygon
-		common.HexToAddress("0x8096A61399e9e9C7e26F3cA5B73D7b2DbB1FeCC"), // → Base
+		common.HexToAddress("0x8096A61399e9e9C7e26F3cA5B73D7b2DbB1FeCC"),  // → Base
 	},
 	10: { // Optimism → various
 		common.HexToAddress("0x15F52286C0FF1d7A7dDbC9E300dd66628D46d4e6"), // → Ethereum
@@ -79,7 +79,7 @@ var OnRampAddresses = map[uint64][]common.Address{
 		common.HexToAddress("0xD1e12b64e77AcA0cde3E5a23f7Ef8b10Ff0f5a7D"), // → Base
 	},
 	8453: { // Base → various
-		common.HexToAddress("0x3E8CaD61Bc0C13f9cAbB5F59B4C8faBCdB7BDd0"), // → Ethereum
+		common.HexToAddress("0x3E8CaD61Bc0C13f9cAbB5F59B4C8faBCdB7BDd0"),  // → Ethereum
 		common.HexToAddress("0x6B90Ec3c44A5a50B5e9eB2Fd3d1b49D7c3A23BE4"), // → Arbitrum
 		common.HexToAddress("0x1CD7e2F39914a24e4561700cb3C4AD69B558bcDB"), // → Optimism
 	},
@@ -108,7 +108,7 @@ var OffRampAddresses = map[uint64][]common.Address{
 		common.HexToAddress("0x9E32088F3c1a5EB38D32d1Ec6ba0bCBF499DC9ac"), // ← Base
 	},
 	10: { // Optimism ← various
-		common.HexToAddress("0x33F54De59419570E33De8A4A3c6E5d5dFBc3Be6"), // ← Ethereum
+		common.HexToAddress("0x33F54De59419570E33De8A4A3c6E5d5dFBc3Be6"),  // ← Ethereum
 		common.HexToAddress("0xA0C1740154590c15B1f56Ed85E01B2E6e14E7dEF"), // ← Arbitrum
 		common.HexToAddress("0x1E2F8bCFb87F3D6aB77E30A2Ad7bB1DE8571af8E"), // ← Base
 	},
@@ -128,13 +128,15 @@ var OffRampAddresses = map[uint64][]common.Address{
 // ccipABI defines the ABI for the two CCIP events we index.
 //
 // CCIPSendRequested (OnRamp v1.2):
-//   The full EVM2EVMMessage struct is emitted as a single non-indexed parameter.
-//   We extract: messageId, sequenceNumber, sender, receiver, sourceChainSelector,
-//   nonce, feeToken, feeTokenAmount, gasLimit, data, tokenAmounts.
+//
+//	The full EVM2EVMMessage struct is emitted as a single non-indexed parameter.
+//	We extract: messageId, sequenceNumber, sender, receiver, sourceChainSelector,
+//	nonce, feeToken, feeTokenAmount, gasLimit, data, tokenAmounts.
 //
 // ExecutionStateChanged (OffRamp v1.2):
-//   sequenceNumber and messageId are both indexed, making them cheap to filter.
-//   state is the execution outcome (0=Untouched, 1=InProgress, 2=Success, 3=Failure).
+//
+//	sequenceNumber and messageId are both indexed, making them cheap to filter.
+//	state is the execution outcome (0=Untouched, 1=InProgress, 2=Success, 3=Failure).
 const ccipABI = `[
 	{
 		"anonymous": false,
@@ -492,10 +494,11 @@ func (d *CCIPDecoder) decodeCCIPSendRequested(
 // CCIPSendRequested event on the source chain.
 //
 // Execution states:
-//   0 = Untouched (message not yet attempted)
-//   1 = InProgress (execution currently in flight)
-//   2 = Success    (execution completed successfully)
-//   3 = Failure    (execution reverted or ran out of gas)
+//
+//	0 = Untouched (message not yet attempted)
+//	1 = InProgress (execution currently in flight)
+//	2 = Success    (execution completed successfully)
+//	3 = Failure    (execution reverted or ran out of gas)
 func (d *CCIPDecoder) decodeExecutionStateChanged(
 	log ethtypes.Log,
 	rawEvent *decoder.RawEvent,

--- a/internal/decoder/ccip/decoder_test.go
+++ b/internal/decoder/ccip/decoder_test.go
@@ -12,33 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// buildEVM2EVMMessage constructs an ABI-encoded CCIPSendRequested log Data field
-// using the EVM2EVMMessage tuple defined in ccipABI.
-func buildCCIPSendRequestedData(t *testing.T, msg evm2EVMMessage) []byte {
-	t.Helper()
-
-	parsedABI, err := abi.JSON(strings.NewReader(ccipABI))
-	require.NoError(t, err)
-
-	event := parsedABI.Events["CCIPSendRequested"]
-
-	// Build the struct map that matches the ABI tuple layout.
-	// go-ethereum's abi package can encode tuples from Go structs via Copy/Pack.
-	// We use a map of field name → value to pack the tuple.
-	tokenAmounts := make([]struct {
-		Token  common.Address
-		Amount *big.Int
-	}, len(msg.TokenAmounts))
-	for i, ta := range msg.TokenAmounts {
-		tokenAmounts[i].Token = ta.Token
-		tokenAmounts[i].Amount = ta.Amount
-	}
-
-	packed, err := event.Inputs.Pack(msg)
-	require.NoError(t, err)
-	return packed
-}
-
 // newTestDecoder returns a CCIPDecoder for use in tests.
 func newTestDecoder() *CCIPDecoder {
 	return NewCCIPDecoder()
@@ -209,7 +182,7 @@ func TestDecodeCCIPSendRequested_WithTokenTransfer(t *testing.T) {
 	msgIDArr[31] = 0x42
 
 	tokenAddr := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48") // USDC
-	tokenAmount := big.NewInt(1000_000000) // 1000 USDC
+	tokenAmount := big.NewInt(1000_000000)                                         // 1000 USDC
 
 	msg := evm2EVMMessage{
 		SequenceNumber:      1,

--- a/internal/normalizer/normalizer.go
+++ b/internal/normalizer/normalizer.go
@@ -56,9 +56,9 @@ func Normalize(event *decoder.RawEvent) (*Result, error) {
 	case "Executed":
 		return normalizeAxelarExecuted(event)
 	case "CCIPSendRequested":
-    	return normalizeCCIPSendRequested(event)
+		return normalizeCCIPSendRequested(event)
 	case "ExecutionStateChanged":
-    	return normalizeCCIPExecutionStateChanged(event)
+		return normalizeCCIPExecutionStateChanged(event)
 	case "LogMessagePublished":
 		return normalizeLogMessagePublished(event)
 	case "TransferRedeemed":
@@ -453,7 +453,8 @@ func normalizeCCIPExecutionStateChanged(event *decoder.RawEvent) (*Result, error
 
 	// Map CCIP execution state to our unified MessageStatus.
 	// Only Success (2) and Failure (3) are terminal states worth persisting.
-	// Untouched (0) and InProgress (1) are transient — skip them.
+	// Untouched (0) and InProgress (1) are transient — skip them entirely
+	// to avoid the correlator accidentally updating messages.
 	var status types.MessageStatus
 	switch stateNum {
 	case 2: // ExecutionStateSuccess
@@ -461,9 +462,7 @@ func normalizeCCIPExecutionStateChanged(event *decoder.RawEvent) (*Result, error
 	case 3: // ExecutionStateFailure
 		status = types.StatusFailed
 	default:
-		// Non-terminal state — the correlator will log a warning and skip.
-		// Return a correlation result with the key so the correlator can decide.
-		status = types.StatusPending
+		return nil, fmt.Errorf("ExecutionStateChanged non-terminal state %d, skipping", stateNum)
 	}
 
 	msg := &types.Message{

--- a/internal/normalizer/normalizer_test.go
+++ b/internal/normalizer/normalizer_test.go
@@ -70,7 +70,6 @@ func newOFTSentEvent() *decoder.RawEvent {
 	}
 }
 
-
 func newLogMessagePublishedEvent() *decoder.RawEvent {
 	return &decoder.RawEvent{
 		Protocol:    "wormhole",
@@ -81,14 +80,14 @@ func newLogMessagePublishedEvent() *decoder.RawEvent {
 		Timestamp:   1706000000,
 		EventType:   "LogMessagePublished",
 		Data: map[string]string{
-			"sender":          "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
-			"emitter_address": "0x0000000000000000000000003ee18b2214aff97000d974cf647e7c347e8fa585",
-			"sequence":        "42",
-			"nonce":           "7",
+			"sender":            "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+			"emitter_address":   "0x0000000000000000000000003ee18b2214aff97000d974cf647e7c347e8fa585",
+			"sequence":          "42",
+			"nonce":             "7",
 			"consistency_level": "15",
-			"payload":         "0xdeadbeef",
-			"emitter_chain":   "2",
-			"message_id":      "2/0x0000000000000000000000003ee18b2214aff97000d974cf647e7c347e8fa585/42",
+			"payload":           "0xdeadbeef",
+			"emitter_chain":     "2",
+			"message_id":        "2/0x0000000000000000000000003ee18b2214aff97000d974cf647e7c347e8fa585/42",
 		},
 	}
 }
@@ -810,7 +809,6 @@ func TestNormalizeTransferRedeemed_InvalidSequence(t *testing.T) {
 	}
 }
 
-
 // ─── CCIP normalizer test additions ──────────────────────────────────────
 
 // newCCIPSendRequestedEvent returns a sample CCIPSendRequested raw event
@@ -825,20 +823,20 @@ func newCCIPSendRequestedEvent() *decoder.RawEvent {
 		Timestamp:   1708000000,
 		EventType:   "CCIPSendRequested",
 		Data: map[string]string{
-			"message_id":           "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
-			"sequence_number":      "42",
-			"sender":               "0x1111111111111111111111111111111111111111",
-			"receiver":             "0x2222222222222222222222222222222222222222",
-			"nonce":                "7",
-			"src_chain_id":         "1",
+			"message_id":            "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+			"sequence_number":       "42",
+			"sender":                "0x1111111111111111111111111111111111111111",
+			"receiver":              "0x2222222222222222222222222222222222222222",
+			"nonce":                 "7",
+			"src_chain_id":          "1",
 			"source_chain_selector": "5009297550715157269",
-			"fee_token":            "0x3333333333333333333333333333333333333333",
-			"fee_token_amount":     "100000000000000",
-			"gas_limit":            "200000",
-			"data":                 "0x",
-			"token_count":          "1",
-			"token":                "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-			"amount":               "1000000000",
+			"fee_token":             "0x3333333333333333333333333333333333333333",
+			"fee_token_amount":      "100000000000000",
+			"gas_limit":             "200000",
+			"data":                  "0x",
+			"token_count":           "1",
+			"token":                 "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+			"amount":                "1000000000",
 		},
 	}
 }
@@ -854,18 +852,18 @@ func newCCIPMessageEvent() *decoder.RawEvent {
 		Timestamp:   1708000100,
 		EventType:   "CCIPSendRequested",
 		Data: map[string]string{
-			"message_id":           "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-			"sequence_number":      "1",
-			"sender":               "0x4444444444444444444444444444444444444444",
-			"receiver":             "0x5555555555555555555555555555555555555555",
-			"nonce":                "1",
-			"src_chain_id":         "42161",
+			"message_id":            "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			"sequence_number":       "1",
+			"sender":                "0x4444444444444444444444444444444444444444",
+			"receiver":              "0x5555555555555555555555555555555555555555",
+			"nonce":                 "1",
+			"src_chain_id":          "42161",
 			"source_chain_selector": "4949039107694359620",
-			"fee_token":            "0x6666666666666666666666666666666666666666",
-			"fee_token_amount":     "50000000000000",
-			"gas_limit":            "150000",
-			"data":                 "0xdeadbeef",
-			"token_count":          "0",
+			"fee_token":             "0x6666666666666666666666666666666666666666",
+			"fee_token_amount":      "50000000000000",
+			"gas_limit":             "150000",
+			"data":                  "0xdeadbeef",
+			"token_count":           "0",
 		},
 	}
 }
@@ -1164,6 +1162,19 @@ func TestNormalizeCCIPExecutionStateChanged_InvalidState(t *testing.T) {
 	_, err := Normalize(event)
 	if err == nil {
 		t.Fatal("expected error for invalid state")
+	}
+}
+
+func TestNormalizeCCIPExecutionStateChanged_NonTerminalStateSkipped(t *testing.T) {
+	// States 0 (Untouched) and 1 (InProgress) are non-terminal and must be
+	// skipped to avoid the correlator accidentally updating messages.
+	for _, state := range []string{"0", "1"} {
+		event := newCCIPExecutionStateChangedEvent()
+		event.Data["state"] = state
+		_, err := Normalize(event)
+		if err == nil {
+			t.Errorf("expected error for non-terminal state %s, got nil", state)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements the Chainlink CCIP (Cross-Chain Interoperability Protocol) v1.2
decoder as part of Milestone 3 (Multi-Protocol Expansion), completing the
third of four planned protocol decoders. This PR adds the full
`CCIPSendRequested` → `ExecutionStateChanged` pipeline including ABI decoding,
chain selector mapping, normalisation, status-aware correlation, and a
comprehensive test suite covering all acceptance criteria.

Closes #27 · Part of akave-ai/akave-pldg#37

---

## Background & Motivation

Chainlink CCIP is a cross-chain messaging and token transfer protocol that
handles billions of dollars in value across major EVM chains. Unlike LayerZero
(single GUID) and Wormhole (composite emitterChain/emitterAddress/sequence),
CCIP uses a **globally unique `messageId` (bytes32)** as its sole correlation
key, making it the simplest correlation model of the four protocols.

CCIP's architecture is also distinct from the other protocols in that it uses a
**pairwise OnRamp/OffRamp model**: each source-destination chain pair has a
dedicated OnRamp contract (source) and OffRamp contract (destination). This
means a single chain can have many OnRamp addresses (one per destination) and
many OffRamp addresses (one per source). Both contract types emit events the
indexer needs to capture, so `ContractAddresses()` returns all OnRamp and
OffRamp addresses for a given chain, deduplicated.

CCIP also introduces a concept the other protocols don't have: **execution
states**. `ExecutionStateChanged` fires for every state transition, not just
terminal ones. States 0 (Untouched) and 1 (InProgress) are transient and must
not trigger a status update. Only state 2 (Success) → `StatusExecuted` and
state 3 (Failure) → `StatusFailed` are persisted, making this the first decoder
with a `StatusFailed` path.

**References:**
- [Chainlink CCIP Architecture](https://docs.chain.link/ccip/architecture)
- [CCIP Supported Networks v1.2.0](https://docs.chain.link/ccip/supported-networks/v1_2_0/mainnet)
- [CCIP Contract Source — OnRamp.sol](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/ccip/OnRamp.sol)
- [CCIP Contract Source — OffRamp.sol](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/ccip/OffRamp.sol)
- [CCIP Chain Selector Registry](https://docs.chain.link/ccip/supported-networks)

---

## Architecture

### Event Flow
```
Source Chain (e.g. Ethereum)
  │
  ├── OnRamp: 0x925228D7...
  │     └── CCIPSendRequested(EVM2EVMMessage message)
  │           │
  │           ├── decoder:    extract messageId, sender, receiver,
  │           │               sourceChainSelector, nonce, feeToken,
  │           │               feeTokenAmount, gasLimit, data, tokenAmounts
  │           └── normalizer: create pending Message
  │                           type = TokenTransfer if token_count > 0
  │                           type = Message if token_count == 0
  │                           message_id = messageId hex string
  │
  │  [CCIP DON (Decentralised Oracle Network) signs commitment off-chain]
  │
Destination Chain (e.g. Arbitrum)
  │
  ├── OffRamp: 0x91e46c...
  │     └── ExecutionStateChanged(
  │               uint64 indexed sequenceNumber,
  │               bytes32 indexed messageId,
  │               uint8 state,
  │               bytes returnData
  │           )
  │           │
  │           ├── decoder:    extract messageId (from Topics[2]),
  │           │               state, state_name, return_data
  │           └── normalizer: build CorrelationKey{MessageID: messageId}
  │                           state 2 → StatusExecuted
  │                           state 3 → StatusFailed
  │                           states 0,1 → StatusPending (skip/warn)
  │                           → FindByCorrelationKey → UpdateDestination
```

### Correlation Model

CCIP is the simplest correlation model across all four protocols. The
`messageId` bytes32 appears identically in both events:
```
CCIPSendRequested  → rawEvent.Data["message_id"] = messageId.Hex()
                   → Message.MessageID = message_id
                   → stored in messages.message_id

ExecutionStateChanged → rawEvent.Data["message_id"] = Topics[2].Hex()
                      → CorrelationKey.MessageID = message_id
                      → FindByCorrelationKey(protocol, messageID="0x...")
```

The `CorrelationKey.MessageID` path (introduced for Axelar's `commandId`)
handles this lookup directly, with zero nonce/sender matching required.

### Chain Selector Mapping

CCIP uses 64-bit chain selectors that are distinct from EVM chain IDs. The
mapping is provided by Chainlink's official documentation:

| CCIP Selector | EVM Chain ID | Network |
|---|---|---|
| 5009297550715157269 | 1 | Ethereum Mainnet |
| 4949039107694359620 | 42161 | Arbitrum One |
| 3734403246176062136 | 10 | Optimism |
| 15971525489660198786 | 8453 | Base |
| 4051577828743386545 | 137 | Polygon |
| 6433500567565415381 | 43114 | Avalanche C-Chain |
| 11344663589394136015 | 56 | BNB Smart Chain |
| 6101244977088475029 | 59144 | Linea |
| 1346049177634351622 | 534352 | Scroll |

Testnets (Sepolia, Arbitrum Sepolia, Base Sepolia, etc.) are also mapped.
Both directions are provided (`ChainSelectorToEVM` and `EVMToChainSelector`)
and kept in sync via `init()`.

### ABI Decoding — go-ethereum v1.17 Tuple Handling

The `CCIPSendRequested` event carries a single non-indexed `EVM2EVMMessage`
tuple parameter containing 12 fields including a nested `EVMTokenAmount[]`
slice. Decoding this correctly required working around a go-ethereum v1.17
behaviour:

> When `Inputs.Unpack` is called on a log whose ABI parameter is a single
> tuple, go-ethereum returns an anonymous Go struct as `unpacked[0]`, not a
> `map[string]interface{}` as one might expect from the documentation.
> The struct's field names are Go-capitalised versions of the ABI field names
> (e.g. `messageId` → `MessageId`, `sequenceNumber` → `SequenceNumber`).
> Because the anonymous struct's concrete type is not importable, type
> assertion to a named struct is not possible.

The solution is to use `reflect.ValueOf(unpacked[0])` and `FieldByName()` to
extract each field by its Go-capitalised name. This approach is version-agnostic
and works whether go-ethereum returns a map or a struct.

Two earlier approaches were tried and rejected:
1. `event.Inputs.Copy(&msg, unpacked)` — fails with `cannot unmarshal struct
   into uint64` because `Copy` tries to match by position, not name.
2. `unpacked[0].(map[string]interface{})` — fails because go-ethereum v1.17
   returns an anonymous struct, not a map.

The reflect-based approach is the correct production solution for this version.

---

## Changes

### New files

| File | Purpose |
|---|---|
| `internal/decoder/ccip/decoder.go` | Full CCIP v1.2 decoder — ABI definitions, chain selector maps, OnRamp/OffRamp addresses, `CCIPSendRequested` and `ExecutionStateChanged` decode logic, `ExecutionState` type |
| `internal/decoder/ccip/decoder_test.go` | 20 unit tests covering all decode paths, chain selector maps, execution state strings, error paths, and the messageId consistency regression guard |

### Modified files

| File | Change |
|---|---|
| `internal/normalizer/normalizer.go` | Added `normalizeCCIPSendRequested` and `normalizeCCIPExecutionStateChanged`; added two cases to the `Normalize()` switch |
| `internal/normalizer/normalizer_test.go` | Added 18 CCIP normaliser tests including `TestCCIPMessageIDConsistencyAcrossEvents` correlation safety guard |
| `cmd/indexer/main.go` | Registered `CCIPDecoder` in the decoder registry |

---

## CCIP-Specific Design Decisions

### Execution state filtering

`ExecutionStateChanged` fires for four states, but only two are terminal:

| State | Name | Action |
|---|---|---|
| 0 | Untouched | `StatusPending` — correlator warns and skips |
| 1 | InProgress | `StatusPending` — correlator warns and skips |
| 2 | Success | `StatusExecuted` — `UpdateDestination` called |
| 3 | Failure | `StatusFailed` — `UpdateDestination` called |

This is the first protocol to use `StatusFailed`. The `UpdateDestination`
method in `message_store_pg.go` already accepts any `MessageStatus` value, so
no schema or store changes were needed.

### Token transfer vs. message classification

`CCIPSendRequested` can carry either a pure message (arbitrary `data` bytes,
no tokens) or a token transfer (one or more `EVMTokenAmount` entries). The
decoder populates `token_count` and the normaliser checks it:
```go
if tc := event.Data["token_count"]; tc != "" && tc != "0" {
    msgType = types.TypeTokenTransfer
}
```

This mirrors the `OFTSent` pattern from the LayerZero decoder.

### OnRamp/OffRamp address coverage

CCIP v1.2 deploys a separate OnRamp per (source, destination) pair and a
separate OffRamp per (destination, source) pair. `ContractAddresses()` returns
all OnRamps and OffRamps for the given chain combined, deduplicated via a
`seen` map. This ensures every relevant contract is monitored with a single
`eth_getLogs` call per chain, rather than one call per pair.

### returnData field

When `ExecutionStateChanged` state is 3 (Failure), the `returnData` field
contains the ABI-encoded revert reason (e.g. `0x08c379a0` = `Error(string)`
selector). This is extracted and stored as a hex string in the `RawEvent.Data`
map for forensic use, even though it is not currently exposed through the API.

---

## Test Coverage

| Package | Tests added | What they cover |
|---|---|---|
| `internal/decoder/ccip` | 20 | Protocol name, event topics, contract addresses (known/unknown/dedup), chain selector mapping roundtrip, `ExecutionState.String()` for all 5 values, `CCIPSendRequested` with basic message/token transfer/empty payload/unknown selector/malformed data, `ExecutionStateChanged` for all 4 states/insufficient topics/malformed data, unknown/empty topics, **messageId consistency between both events** |
| `internal/normalizer` | 18 | `CCIPSendRequested` token transfer classification, pure message classification, source fields, payload fields, metadata fee, no destination, missing message_id/sender/invalid src_chain_id/invalid nonce; `ExecutionStateChanged` correlation key structure, destination fields, Success→StatusExecuted, Failure→StatusFailed, missing message_id/state, invalid state; **`TestCCIPMessageIDConsistencyAcrossEvents`** |

All 38 new tests pass. No regressions in existing tests.

---

## Decoder Interface Compliance

`CCIPDecoder` fully implements the `decoder.Decoder` interface:
```go
func (d *CCIPDecoder) Protocol() string
// → "ccip"

func (d *CCIPDecoder) ContractAddresses(chainID uint64) []common.Address
// → deduplicated union of OnRampAddresses[chainID] + OffRampAddresses[chainID]

func (d *CCIPDecoder) EventTopics() []common.Hash
// → [CCIPSendRequested.ID, ExecutionStateChanged.ID]

func (d *CCIPDecoder) Decode(log ethtypes.Log, chainID uint64) (*decoder.RawEvent, error)
// → dispatches to decodeCCIPSendRequested or decodeExecutionStateChanged
```

Registration is one line:
```go
ccipDecoder := ccip.NewCCIPDecoder()
registry.Register(ccipDecoder)
```

---

## Correlation Safety

The critical correctness invariant for CCIP is simpler than Wormhole but still
worth making explicit:

**`CCIPSendRequested` stores `messageId` as `common.BytesToHash(arr[:]).Hex()`.**
**`ExecutionStateChanged` stores `messageId` as `log.Topics[2].Hex()`.**

Both produce a `0x`-prefixed 64-character lowercase hex string from the same
bytes32 value. `TestMessageIDConsistency_SendAndExecution` (decoder) and
`TestCCIPMessageIDConsistencyAcrossEvents` (normaliser) assert byte-for-byte
equality across both paths. If either side ever changes its encoding,
`FindByCorrelationKey` would silently return no rows and every CCIP message
would remain `pending` forever — these tests prevent that regression.

---

## Acceptance Criteria

- [x] Decoder correctly parses at least 3 sample CCIP events (unit tested) — 20 decoder tests, all passing
- [x] `CCIPSendRequested` creates a pending message — `TestNormalizeCCIPSendRequested_TokenTransfer`, `TestNormalizeCCIPSendRequested_PureMessage`
- [x] `ExecutionStateChanged` correlates and updates status to `executed` — `TestNormalizeCCIPExecutionStateChanged_SuccessStatus`
- [x] CCIP chain selector mapping covers all major supported chains — `TestChainSelectorToEVM_MajorChains`, `TestEVMToChainSelector_Roundtrip`
- [x] `CCIPSendRequested` message type is `token_transfer` when `token_count > 0` — `TestNormalizeCCIPSendRequested_TokenTransfer`
- [x] `ExecutionStateChanged` with state 3 sets `StatusFailed` — `TestNormalizeCCIPExecutionStateChanged_FailureStatus`
- [x] Decoder registered in registry — `cmd/indexer/main.go`

---

## Test Plan

- [x] `make build` compiles without errors
- [x] `make test` passes all tests — 0 failures, 0 regressions
- [x] `CCIPSendRequested` correctly extracts all 12 EVM2EVMMessage fields via `reflect`
- [x] `ExecutionStateChanged` correctly reads all 3 indexed topics and 2 non-indexed fields
- [x] Chain selector → EVM chain ID mapping is correct and bidirectionally consistent
- [x] messageId format is byte-for-byte identical between source and destination events
- [x] Execution states 0 and 1 do not trigger destination updates
- [x] Execution state 3 sets `StatusFailed` (first use of this status in the project)

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Migrations are reversible (no DB changes in this PR)
- [x] All new code has corresponding unit tests
- [x] Decoder registration follows the established one-`Register()`-call pattern

## Summary by Sourcery

Add a Chainlink CCIP v1.2 decoding and normalization pipeline and register it in the indexer, enabling end‑to‑end handling of CCIP messages and execution state updates.

New Features:
- Introduce a CCIP decoder that parses CCIPSendRequested and ExecutionStateChanged events, including chain selector mapping and token transfer details.
- Add CCIP-specific normalization for send and execution events, producing pending messages and status updates driven by CCIP execution states.

Enhancements:
- Register the CCIP decoder in the indexer’s decoder registry so CCIP logs are ingested alongside existing protocols.

Tests:
- Add comprehensive decoder tests for CCIP event topics, contract address coverage, chain selector mappings, execution state naming, and messageId correlation between events.
- Add CCIP normalizer tests covering message vs token-transfer classification, source and destination field population, execution success/failure status mapping, validation errors, and cross-event messageId consistency.